### PR TITLE
Reduce cis docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*/__pycache__
+.git
+env
+.gitignore
+.travis.yml
+Makefile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.2
+FROM python:3.7.2-slim
 WORKDIR /usr/src/app
 COPY . .
 RUN pip install --no-cache-dir -r prod-requirements.txt


### PR DESCRIPTION
https://trello.com/c/8GluROYV/45-reduce-cis-docker-image-size
This reduces the cis image size from 1.15GB to 257MB:
```shell
codealife/al-cis                                                 latest              f00c8eca3750        19 seconds ago      257MB
codealife/al-cis                                                 <none>              b86cd45f3c28        2 weeks ago         1.15GB
```